### PR TITLE
Мое видение расшифровки

### DIFF
--- a/chat-client/src/ru/gb/jt/chat/client/ClientGUI.java
+++ b/chat-client/src/ru/gb/jt/chat/client/ClientGUI.java
@@ -60,6 +60,7 @@ public class ClientGUI extends JFrame implements ActionListener, Thread.Uncaught
         btnSend.addActionListener(this);
         tfMessage.addActionListener(this);
         btnLogin.addActionListener(this);
+        btnDisconnect.addActionListener(this);
 
         panelTop.add(tfIPAddress);
         panelTop.add(tfPort);
@@ -112,11 +113,6 @@ public class ClientGUI extends JFrame implements ActionListener, Thread.Uncaught
         tfMessage.grabFocus();
         socketThread.sendMessage(msg);
 
-        if (!"".equals(msg)) {
-            tfMessage.setText(null);
-            tfMessage.grabFocus();
-            socketThread.sendMessage(msg);
-        }
 
 //        putLog(String.format("%s: %s", username, msg));
 //        wrtMsgToLogFile(msg, username);
@@ -136,7 +132,7 @@ public class ClientGUI extends JFrame implements ActionListener, Thread.Uncaught
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                log.append(msg + "\n");
+                log.append(Extract.extractMsg(msg)  + "\n");
                 log.setCaretPosition(log.getDocument().getLength());
             }
         });

--- a/chat-client/src/ru/gb/jt/chat/client/Extract.java
+++ b/chat-client/src/ru/gb/jt/chat/client/Extract.java
@@ -1,0 +1,13 @@
+package ru.gb.jt.chat.client;
+
+import ru.gb.jt.chat.library.Library;
+
+public class Extract {
+    public static String extractMsg(String msg){
+        if (msg.contains(Library.AUTH_ACCEPT)) {
+            return "В чат вошел " + msg.substring(Library.AUTH_ACCEPT.length() + Library.DELIMITER.length());
+        } else if (msg.contains(Library.TYPE_BROADCAST)) {
+            return "СЕРВЕР ИНФО: " + msg.substring(Library.TYPE_BROADCAST.length() + Library.DELIMITER.length());
+        } else return msg;
+    }
+}


### PR DESCRIPTION
Для начала добавим листенер дисконекту, а то это пропустили и удалим задвоение вывода в лог клиента.

Расшифровкой на мой взгляд должен уметь заниматься клиент. Учитывая что он знает протокол сообщений, описанный в Library, и к тому же каждый новый вариант клиента без труда сможет расшифровывать и выводить сообщения как ему надо.

Для этого создан статический класс Extract с одним статическим методом расшифровки. Он включен в метод putLog() в клиенте.
 
Метод Extract.extractMsg() получает строку, анализирует на известные в протоколе Library ключевые слова и преобразует строку так , как нужно в этой версии клиента.
Ну или в принципе можно было вместо класса интерфейс сделать...

На мой взгляд достаточно легко поддерживается и модифицируется. 